### PR TITLE
헤더 네비게이션 로고 위치 정중앙으로 조정.

### DIFF
--- a/antoliny_daily/templates/includes/nav.html
+++ b/antoliny_daily/templates/includes/nav.html
@@ -1,11 +1,11 @@
 {% load static %}
 
-<nav class="flex justify-between items-center py-2 bg-base-brown-400 dark:bg-base-brown-800">
-  <a class="flex items-center justify-center gap-2 my-0 mx-auto" href="/">
+<nav class="relative flex justify-between items-center py-4 bg-base-brown-400 dark:bg-base-brown-800">
+  <a class="absolute left-1/2 -translate-x-1/2 flex items-center justify-center gap-2 my-0 mx-auto" href="/">
     <span class="font-logo font-bold text-3xl text-white">ANTOLINY</span>
     <img class="h-[60px]" alt="Antoliny Daily Logo" src="{% static 'img/logo.png' %}">
   </a>
-  <div class="mx-8">
+  <div class="ml-auto mx-8">
       <ul>
         <li class="relative"
            x-data="{


### PR DESCRIPTION
<img width="1436" height="272" alt="Screenshot 2025-09-01 at 5 20 10 PM" src="https://github.com/user-attachments/assets/e7bcff5c-ed06-4f6b-a24d-acf7cb888d06" />

absolute포지션을 사용하여 Logo(Antoliny)의 위치를 헤더 네비게이션 정 중앙에 배치하였습니다.